### PR TITLE
Block Selection Form Updates...

### DIFF
--- a/MCPixelArtConverter/MCPACBlockSelectionForm.Designer.cs
+++ b/MCPixelArtConverter/MCPACBlockSelectionForm.Designer.cs
@@ -29,128 +29,177 @@
         private void InitializeComponent()
         {
             this.checkedListBoxBlockStates = new System.Windows.Forms.CheckedListBox();
-            this.textureImage = new MCPixelArtConverter.PictureBoxWithSettings();
             this.checkedListBoxVariants = new System.Windows.Forms.CheckedListBox();
             this.lblSide = new System.Windows.Forms.Label();
             this.cmbSide = new System.Windows.Forms.ComboBox();
-            this.btnUnselectAll = new System.Windows.Forms.Button();
             this.btnSaveSelection = new System.Windows.Forms.Button();
             this.btnLoadSelection = new System.Windows.Forms.Button();
-            this.btnSelectAll = new System.Windows.Forms.Button();
+            this.labelFilter = new System.Windows.Forms.Label();
+            this.textBoxFilter = new System.Windows.Forms.TextBox();
+            this.checkBoxSelectAllBlockStates = new System.Windows.Forms.CheckBox();
+            this.splitContainer1 = new System.Windows.Forms.SplitContainer();
+            this.textureImage = new MCPixelArtConverter.PictureBoxWithSettings();
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
+            this.splitContainer1.Panel1.SuspendLayout();
+            this.splitContainer1.Panel2.SuspendLayout();
+            this.splitContainer1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.textureImage)).BeginInit();
             this.SuspendLayout();
             // 
             // checkedListBoxBlockStates
             // 
-            this.checkedListBoxBlockStates.FormattingEnabled = true;
-            this.checkedListBoxBlockStates.Location = new System.Drawing.Point(12, 42);
+            this.checkedListBoxBlockStates.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left)));
+            this.checkedListBoxBlockStates.IntegralHeight = false;
+            this.checkedListBoxBlockStates.Location = new System.Drawing.Point(38, 131);
             this.checkedListBoxBlockStates.Name = "checkedListBoxBlockStates";
-            this.checkedListBoxBlockStates.Size = new System.Drawing.Size(217, 499);
-            this.checkedListBoxBlockStates.Sorted = true;
-            this.checkedListBoxBlockStates.TabIndex = 2;
+            this.checkedListBoxBlockStates.Size = new System.Drawing.Size(566, 676);
+            this.checkedListBoxBlockStates.TabIndex = 32;
             this.checkedListBoxBlockStates.ItemCheck += new System.Windows.Forms.ItemCheckEventHandler(this.checkedListBoxBlockStates_ItemCheck);
-            this.checkedListBoxBlockStates.SelectedIndexChanged += new System.EventHandler(this.checkedListBoxBlockStates_SelectedIndexChanged);
-            // 
-            // textureImage
-            // 
-            this.textureImage.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.textureImage.InterpolationMode = System.Drawing.Drawing2D.InterpolationMode.NearestNeighbor;
-            this.textureImage.Location = new System.Drawing.Point(458, 44);
-            this.textureImage.Name = "textureImage";
-            this.textureImage.PixelOffsetMode = System.Drawing.Drawing2D.PixelOffsetMode.Half;
-            this.textureImage.Size = new System.Drawing.Size(320, 320);
-            this.textureImage.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
-            this.textureImage.TabIndex = 3;
-            this.textureImage.TabStop = false;
+            this.checkedListBoxBlockStates.SelectedValueChanged += new System.EventHandler(this.checkedListBoxBlockStates_SelectedValueChanged);
             // 
             // checkedListBoxVariants
             // 
-            this.checkedListBoxVariants.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.checkedListBoxVariants.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.checkedListBoxVariants.FormattingEnabled = true;
-            this.checkedListBoxVariants.Location = new System.Drawing.Point(235, 42);
+            this.checkedListBoxVariants.IntegralHeight = false;
+            this.checkedListBoxVariants.Location = new System.Drawing.Point(0, 0);
+            this.checkedListBoxVariants.Margin = new System.Windows.Forms.Padding(8, 7, 8, 7);
             this.checkedListBoxVariants.Name = "checkedListBoxVariants";
-            this.checkedListBoxVariants.Size = new System.Drawing.Size(217, 499);
+            this.checkedListBoxVariants.Size = new System.Drawing.Size(561, 676);
             this.checkedListBoxVariants.Sorted = true;
-            this.checkedListBoxVariants.TabIndex = 4;
+            this.checkedListBoxVariants.TabIndex = 7;
             this.checkedListBoxVariants.ItemCheck += new System.Windows.Forms.ItemCheckEventHandler(this.checkedListBoxVariants_ItemCheck);
             this.checkedListBoxVariants.SelectedIndexChanged += new System.EventHandler(this.checkedListBoxVariants_SelectedIndexChanged);
             // 
             // lblSide
             // 
-            this.lblSide.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.lblSide.AutoSize = true;
-            this.lblSide.Location = new System.Drawing.Point(463, 17);
+            this.lblSide.Location = new System.Drawing.Point(615, 88);
+            this.lblSide.Margin = new System.Windows.Forms.Padding(8, 0, 8, 0);
             this.lblSide.Name = "lblSide";
-            this.lblSide.Size = new System.Drawing.Size(56, 13);
+            this.lblSide.Size = new System.Drawing.Size(152, 32);
             this.lblSide.TabIndex = 24;
-            this.lblSide.Text = "Block side";
+            this.lblSide.Text = "Block side:";
             // 
             // cmbSide
             // 
-            this.cmbSide.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.cmbSide.FormattingEnabled = true;
-            this.cmbSide.Location = new System.Drawing.Point(525, 12);
+            this.cmbSide.Location = new System.Drawing.Point(783, 78);
+            this.cmbSide.Margin = new System.Windows.Forms.Padding(8, 7, 8, 7);
             this.cmbSide.Name = "cmbSide";
-            this.cmbSide.Size = new System.Drawing.Size(105, 21);
-            this.cmbSide.TabIndex = 23;
-            // 
-            // btnUnselectAll
-            // 
-            this.btnUnselectAll.Location = new System.Drawing.Point(93, 12);
-            this.btnUnselectAll.Name = "btnUnselectAll";
-            this.btnUnselectAll.Size = new System.Drawing.Size(75, 23);
-            this.btnUnselectAll.TabIndex = 25;
-            this.btnUnselectAll.Text = "Unselect All";
-            this.btnUnselectAll.UseVisualStyleBackColor = true;
-            this.btnUnselectAll.Click += new System.EventHandler(this.btnUnselectAll_Click);
+            this.cmbSide.Size = new System.Drawing.Size(336, 39);
+            this.cmbSide.TabIndex = 6;
             // 
             // btnSaveSelection
             // 
-            this.btnSaveSelection.Location = new System.Drawing.Point(268, 12);
+            this.btnSaveSelection.Location = new System.Drawing.Point(289, 16);
+            this.btnSaveSelection.Margin = new System.Windows.Forms.Padding(8, 7, 8, 7);
             this.btnSaveSelection.Name = "btnSaveSelection";
-            this.btnSaveSelection.Size = new System.Drawing.Size(89, 23);
-            this.btnSaveSelection.TabIndex = 26;
+            this.btnSaveSelection.Size = new System.Drawing.Size(237, 55);
+            this.btnSaveSelection.TabIndex = 1;
             this.btnSaveSelection.Text = "Save selection";
             this.btnSaveSelection.UseVisualStyleBackColor = true;
             this.btnSaveSelection.Click += new System.EventHandler(this.btnSaveSelection_Click);
             // 
             // btnLoadSelection
             // 
-            this.btnLoadSelection.Location = new System.Drawing.Point(174, 12);
+            this.btnLoadSelection.Location = new System.Drawing.Point(38, 16);
+            this.btnLoadSelection.Margin = new System.Windows.Forms.Padding(8, 7, 8, 7);
             this.btnLoadSelection.Name = "btnLoadSelection";
-            this.btnLoadSelection.Size = new System.Drawing.Size(88, 23);
-            this.btnLoadSelection.TabIndex = 28;
+            this.btnLoadSelection.Size = new System.Drawing.Size(235, 55);
+            this.btnLoadSelection.TabIndex = 0;
             this.btnLoadSelection.Text = "Load selection";
             this.btnLoadSelection.UseVisualStyleBackColor = true;
             this.btnLoadSelection.Click += new System.EventHandler(this.btnLoadSelection_Click);
             // 
-            // btnSelectAll
+            // labelFilter
             // 
-            this.btnSelectAll.Location = new System.Drawing.Point(12, 12);
-            this.btnSelectAll.Name = "btnSelectAll";
-            this.btnSelectAll.Size = new System.Drawing.Size(75, 23);
-            this.btnSelectAll.TabIndex = 29;
-            this.btnSelectAll.Text = "Select All";
-            this.btnSelectAll.UseVisualStyleBackColor = true;
-            this.btnSelectAll.Click += new System.EventHandler(this.btnSelectAll_Click);
+            this.labelFilter.AutoSize = true;
+            this.labelFilter.Location = new System.Drawing.Point(86, 88);
+            this.labelFilter.Name = "labelFilter";
+            this.labelFilter.Size = new System.Drawing.Size(86, 32);
+            this.labelFilter.TabIndex = 30;
+            this.labelFilter.Text = "Filter:";
+            // 
+            // textBoxFilter
+            // 
+            this.textBoxFilter.Location = new System.Drawing.Point(178, 83);
+            this.textBoxFilter.Name = "textBoxFilter";
+            this.textBoxFilter.Size = new System.Drawing.Size(426, 38);
+            this.textBoxFilter.TabIndex = 4;
+            this.textBoxFilter.TextChanged += new System.EventHandler(this.textBoxFilter_TextChanged);
+            // 
+            // checkBoxSelectAllBlockStates
+            // 
+            this.checkBoxSelectAllBlockStates.AutoSize = true;
+            this.checkBoxSelectAllBlockStates.Location = new System.Drawing.Point(46, 87);
+            this.checkBoxSelectAllBlockStates.Name = "checkBoxSelectAllBlockStates";
+            this.checkBoxSelectAllBlockStates.Size = new System.Drawing.Size(34, 33);
+            this.checkBoxSelectAllBlockStates.TabIndex = 3;
+            this.checkBoxSelectAllBlockStates.ThreeState = true;
+            this.checkBoxSelectAllBlockStates.UseVisualStyleBackColor = true;
+            this.checkBoxSelectAllBlockStates.CheckStateChanged += new System.EventHandler(this.checkBoxSelectAllBlockStates_CheckStateChanged);
+            // 
+            // splitContainer1
+            // 
+            this.splitContainer1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.splitContainer1.Location = new System.Drawing.Point(621, 131);
+            this.splitContainer1.Name = "splitContainer1";
+            // 
+            // splitContainer1.Panel1
+            // 
+            this.splitContainer1.Panel1.Controls.Add(this.checkedListBoxVariants);
+            // 
+            // splitContainer1.Panel2
+            // 
+            this.splitContainer1.Panel2.Controls.Add(this.textureImage);
+            this.splitContainer1.Size = new System.Drawing.Size(901, 701);
+            this.splitContainer1.SplitterDistance = 569;
+            this.splitContainer1.TabIndex = 31;
+            // 
+            // textureImage
+            // 
+            this.textureImage.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.textureImage.BackColor = System.Drawing.SystemColors.Window;
+            this.textureImage.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
+            this.textureImage.InterpolationMode = System.Drawing.Drawing2D.InterpolationMode.NearestNeighbor;
+            this.textureImage.Location = new System.Drawing.Point(4, 0);
+            this.textureImage.Margin = new System.Windows.Forms.Padding(8, 7, 8, 7);
+            this.textureImage.Name = "textureImage";
+            this.textureImage.PixelOffsetMode = System.Drawing.Drawing2D.PixelOffsetMode.Half;
+            this.textureImage.Size = new System.Drawing.Size(316, 316);
+            this.textureImage.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
+            this.textureImage.TabIndex = 3;
+            this.textureImage.TabStop = false;
             // 
             // MCPACBlockSelectionForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(16F, 31F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(790, 567);
-            this.Controls.Add(this.btnSelectAll);
+            this.ClientSize = new System.Drawing.Size(1853, 893);
+            this.Controls.Add(this.splitContainer1);
+            this.Controls.Add(this.checkBoxSelectAllBlockStates);
+            this.Controls.Add(this.checkedListBoxBlockStates);
+            this.Controls.Add(this.textBoxFilter);
+            this.Controls.Add(this.labelFilter);
             this.Controls.Add(this.btnLoadSelection);
             this.Controls.Add(this.btnSaveSelection);
-            this.Controls.Add(this.btnUnselectAll);
             this.Controls.Add(this.lblSide);
             this.Controls.Add(this.cmbSide);
-            this.Controls.Add(this.checkedListBoxVariants);
-            this.Controls.Add(this.textureImage);
-            this.Controls.Add(this.checkedListBoxBlockStates);
+            this.Margin = new System.Windows.Forms.Padding(8, 7, 8, 7);
             this.Name = "MCPACBlockSelectionForm";
             this.Text = "MC Pixel Art Block Selection";
+            this.splitContainer1.Panel1.ResumeLayout(false);
+            this.splitContainer1.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
+            this.splitContainer1.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.textureImage)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
@@ -158,15 +207,16 @@
         }
 
         #endregion
-
-        private System.Windows.Forms.CheckedListBox checkedListBoxBlockStates;
         private PictureBoxWithSettings textureImage;
         private System.Windows.Forms.CheckedListBox checkedListBoxVariants;
         private System.Windows.Forms.Label lblSide;
         private System.Windows.Forms.ComboBox cmbSide;
-        private System.Windows.Forms.Button btnUnselectAll;
         private System.Windows.Forms.Button btnSaveSelection;
         private System.Windows.Forms.Button btnLoadSelection;
-        private System.Windows.Forms.Button btnSelectAll;
+        private System.Windows.Forms.Label labelFilter;
+        private System.Windows.Forms.TextBox textBoxFilter;
+        private System.Windows.Forms.CheckedListBox checkedListBoxBlockStates;
+        private System.Windows.Forms.CheckBox checkBoxSelectAllBlockStates;
+        private System.Windows.Forms.SplitContainer splitContainer1;
     }
 }

--- a/MCPixelArtConverter/MCPACBlockSelectionForm.cs
+++ b/MCPixelArtConverter/MCPACBlockSelectionForm.cs
@@ -12,7 +12,7 @@ using System.Windows.Forms;
 namespace MCPixelArtConverter
 {
     partial class MCPACBlockSelectionForm : Form
-    {        
+    {
         MCResourcePack resourcePack;
 
         public MCPACBlockSelectionForm(MCResourcePack rp)
@@ -25,8 +25,40 @@ namespace MCPixelArtConverter
             cmbSide.SelectedItem = resourcePack.SelectedSide;
             cmbSide.SelectedIndexChanged += cmbSide_SelectedIndexChanged;
 
-            checkedListBoxBlockStates.Items.AddRange(resourcePack.getBlockStates().ToArray());
+            var dt = new DataTable();
+
+            dt.Columns.Add("Item", typeof(string));
+            dt.Columns.Add("BlockState", typeof(MCBlockState));
+            dt.Columns.Add("Checked", typeof(bool));
+
+            foreach (var item in resourcePack.getBlockStates().ToArray())
+            {
+                // BlockStates without variants mess with the .GetSelected() method, which 
+                // causes problems when filtering the list of BlockStates and updating the
+                // "select all/none" checkbox to match.
+
+                // Temporarily skipping items with no variants, until multipart blockstates are
+                // handled. There won't be any variants included, so there wouldn't be
+                // any bitmap to render anyway.
+
+                if (item.GetVariants().Count < 1)
+                    continue;
+                dt.Rows.Add(item.FileName, item, false);
+            }
+
+            dt.AcceptChanges();
+
+            DataView dv = dt.DefaultView;
+            dv.Sort = "Item";
+
+            checkedListBoxBlockStates.DataSource = dv;
+            checkedListBoxBlockStates.DisplayMember = "Item";
+            checkedListBoxBlockStates.ValueMember = "Item";
+
             UpdateBlockStatesChecked();
+
+            // If not already done by the designer...
+            checkedListBoxBlockStates.BindingContext[dv].CurrentChanged += checkedListBoxBlockStates_BindingContext_CurrentChanged;
         }
 
         private void UpdateBlockStatesChecked()
@@ -35,9 +67,12 @@ namespace MCPixelArtConverter
             checkedListBoxBlockStates.ItemCheck -= checkedListBoxBlockStates_ItemCheck;
             for (int i = 0; i <= (checkedListBoxBlockStates.Items.Count - 1); i++)
             {
-                checkedListBoxBlockStates.SetItemChecked(i, ((MCBlockState)checkedListBoxBlockStates.Items[i]).GetSelected());
+                checkedListBoxBlockStates.SetItemChecked(i, ((MCBlockState)((DataRowView)checkedListBoxBlockStates.Items[i])["BlockState"]).GetSelected());
             }
             checkedListBoxBlockStates.ItemCheck += checkedListBoxBlockStates_ItemCheck;
+
+            UpdateCheckboxSelectAll();
+
         }
 
         private void UpdateBlockStateChecked(MCBlockState blockState)
@@ -51,21 +86,25 @@ namespace MCPixelArtConverter
             checkedListBoxBlockStates.ItemCheck += checkedListBoxBlockStates_ItemCheck;
         }
 
-        private void checkedListBoxBlockStates_SelectedIndexChanged(object sender, EventArgs e)
+        private void checkedListBoxBlockStates_SelectedValueChanged(object sender, EventArgs e)
         {
-            if (sender == null)
-                return;
-
             UpdateBlockVariants();
         }
 
-        private void UpdateBlockVariants()
+        private void UpdateBlockVariants(MCBlockState definedState = null)
         {
             checkedListBoxVariants.Items.Clear();
-            MCBlockState blockState = (MCBlockState)checkedListBoxBlockStates.SelectedItem;
+            MCBlockState blockState = null;
+            if (definedState != null)
+                blockState = definedState;
+            else
+            {
+                if(checkedListBoxBlockStates.SelectedItem != null)
+                    blockState = (MCBlockState)((DataRowView)checkedListBoxBlockStates.SelectedItem)["BlockState"];
+            }
             if (blockState == null)
                 return;
-            
+
             checkedListBoxVariants.Items.AddRange(blockState.GetVariants().ToArray());
             UpdateBlockVariantChecked();
         }
@@ -77,20 +116,25 @@ namespace MCPixelArtConverter
             for (int i = 0; i <= (checkedListBoxVariants.Items.Count - 1); i++)
                 checkedListBoxVariants.SetItemChecked(i, ((MCBlockVariant)checkedListBoxVariants.Items[i]).Selected);
             checkedListBoxVariants.ItemCheck += checkedListBoxVariants_ItemCheck;
+
+            ShowFirstSelectedVariantImage();
         }
 
         private void checkedListBoxBlockStates_ItemCheck(object sender, ItemCheckEventArgs e)
         {
-            MCBlockState blockState = (MCBlockState)checkedListBoxBlockStates.Items[e.Index];
+            MCBlockState blockState = (MCBlockState)((DataView)checkedListBoxBlockStates.DataSource)[e.Index]["BlockState"];
             blockState.SetSelected(e.NewValue == CheckState.Checked);
 
+            UpdateBlockStatesChecked();
+
+            // This is already happening. Unsure whether this is needed at all?
             //just change checkbox, the MCBlockVariant selection is already done in the blockState.SetSelected
-            checkedListBoxVariants.ItemCheck -= checkedListBoxVariants_ItemCheck;
-            for (int i = 0; i <= (checkedListBoxVariants.Items.Count - 1); i++)
-            {
-                checkedListBoxVariants.SetItemCheckState(i, e.NewValue);
-            }
-            checkedListBoxVariants.ItemCheck += checkedListBoxVariants_ItemCheck;
+            //checkedListBoxVariants.ItemCheck -= checkedListBoxVariants_ItemCheck;
+            //for (int i = 0; i <= (checkedListBoxVariants.Items.Count - 1); i++)
+            //{
+            //    checkedListBoxVariants.SetItemCheckState(i, e.NewValue);
+            //}
+            //checkedListBoxVariants.ItemCheck += checkedListBoxVariants_ItemCheck;
         }
 
         private void checkedListBoxVariants_ItemCheck(object sender, ItemCheckEventArgs e)
@@ -125,22 +169,6 @@ namespace MCPixelArtConverter
             SetTextureImage((MCBlockVariant)checkedListBoxVariants.SelectedItem);
         }
 
-        private void btnUnselectAll_Click(object sender, EventArgs e)
-        {
-            for (int i = 0; i <= (checkedListBoxBlockStates.Items.Count - 1); i++)
-            {
-                checkedListBoxBlockStates.SetItemCheckState(i, CheckState.Unchecked);
-            }
-        }
-
-        private void btnSelectAll_Click(object sender, EventArgs e)
-        {
-            for (int i = 0; i <= (checkedListBoxBlockStates.Items.Count - 1); i++)
-            {
-                checkedListBoxBlockStates.SetItemCheckState(i, CheckState.Checked);
-            }
-        }
-
         private void btnSaveSelection_Click(object sender, EventArgs e)
         {
             SaveFileDialog saveFileDialog = new SaveFileDialog();
@@ -171,5 +199,102 @@ namespace MCPixelArtConverter
             UpdateBlockStatesChecked();
             UpdateBlockVariantChecked();
         }
+
+        private void textBoxFilter_TextChanged(object sender, EventArgs e)
+        {
+            var dv = checkedListBoxBlockStates.DataSource as DataView;
+            var filter = textBoxFilter.Text.Trim().Length > 0
+                ? $"Item LIKE '*{textBoxFilter.Text}*'"
+                : null;
+
+            dv.RowFilter = filter;
+            UpdateBlockStatesChecked();
+            //UpdateBlockVariants();
+        }
+
+        private void checkBoxSelectAllBlockStates_CheckStateChanged(object sender, EventArgs e)
+        {
+
+            // Ensure that the user only has two states,
+            // even thouth the tristate is used to represent a partial selection
+            checkBoxSelectAllBlockStates.CheckStateChanged -= checkBoxSelectAllBlockStates_CheckStateChanged;
+            if (checkBoxSelectAllBlockStates.CheckState == CheckState.Indeterminate)
+            {
+                checkBoxSelectAllBlockStates.CheckState = CheckState.Unchecked;
+            }
+            checkBoxSelectAllBlockStates.CheckStateChanged += checkBoxSelectAllBlockStates_CheckStateChanged;
+
+            checkedListBoxBlockStates.ItemCheck -= checkedListBoxBlockStates_ItemCheck;
+            checkedListBoxBlockStates.ItemCheck -= checkedListBoxBlockStates_ItemCheck;
+
+            var chk = checkBoxSelectAllBlockStates.CheckState == CheckState.Checked ? true : false;
+            for (var i = 0; i < checkedListBoxBlockStates.Items.Count; i++)
+            {
+                checkedListBoxBlockStates.SetItemChecked(i, chk);
+                var drv = checkedListBoxBlockStates.Items[i] as DataRowView;
+                MCBlockState blockstate = (MCBlockState)drv["BlockState"];
+                blockstate.SetSelected(chk);
+            }
+
+            checkedListBoxBlockStates.ItemCheck += checkedListBoxBlockStates_ItemCheck;
+
+        }
+
+        private void UpdateCheckboxSelectAll()
+        {
+
+            checkBoxSelectAllBlockStates.CheckStateChanged -= checkBoxSelectAllBlockStates_CheckStateChanged;
+
+            var selected = 0;
+
+            for (var i = 0; i < checkedListBoxBlockStates.Items.Count; i++)
+            {
+                selected += checkedListBoxBlockStates.GetItemCheckState(i) == CheckState.Checked ? 1 : 0;
+            }
+
+            if (selected == 0)
+            {
+                checkBoxSelectAllBlockStates.CheckState = CheckState.Unchecked;
+            } else if (selected == checkedListBoxBlockStates.Items.Count)
+            {
+                checkBoxSelectAllBlockStates.CheckState = CheckState.Checked;
+            } else
+            {
+                checkBoxSelectAllBlockStates.CheckState = CheckState.Indeterminate;
+            }
+
+            checkBoxSelectAllBlockStates.CheckStateChanged += checkBoxSelectAllBlockStates_CheckStateChanged;
+
+        }
+        
+        private void checkedListBoxBlockStates_BindingContext_CurrentChanged(object sender, EventArgs e)
+        {
+            MCBlockState blockState = null;
+            if (((CurrencyManager)sender).List.Count > 0)
+            {
+                blockState = ((MCBlockState)(
+                    (DataRowView)
+                        (
+                            (CurrencyManager)sender
+                        ).Current
+                )["BlockState"]);
+            }
+            UpdateBlockVariants(blockState);
+        }
+
+        private void ShowFirstSelectedVariantImage()
+        {
+            SetTextureImage((MCBlockVariant)checkedListBoxVariants.SelectedItem);
+            for (int i = 0; i < checkedListBoxVariants.Items.Count; i++)
+            {
+                if (((MCBlockVariant)checkedListBoxVariants.Items[i]).Selected)
+                {
+                    checkedListBoxVariants.SelectedIndex = i;
+                    break;
+                }
+            }
+
+        }
+
     }
 }


### PR DESCRIPTION
Changed `BlockStates` `CheckedListBox` to bind to a `DataView`, to allow filtering its contents

Added a `TextBox` for use in filtering the `BlockState` `CheckredListBox` to items matching the text entered.

Replaced [Select All] and [Unselect All] buttons with a `CheckBox` that operates on the currently displayed items.

Made the current image update to the first selected variant anytime the `BlockStateVariant` `CheckedListBox` is updated.  So when moving through the `BlockState` `ChecedkListBox`, the image updates according to whichever `BlockState` is selected.

Added split between `BlockStateVariant` `ChecedkListBox` and the image, to allow resizing the `BlockStateVariant` `CheckedListBox`.

Updated the form's layout and anchor settings, so controls resize appropriately.